### PR TITLE
Fix some namespaces on JsonApiResponseTrait

### DIFF
--- a/src/Serializer/JsonApiResponseTrait.php
+++ b/src/Serializer/JsonApiResponseTrait.php
@@ -2,6 +2,7 @@
 
 namespace NilPortugues\Symfony\JsonApiBundle\Serializer;
 
+use NilPortugues\Api\JsonApi;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 
 trait JsonApiResponseTrait
@@ -24,7 +25,7 @@ trait JsonApiResponseTrait
     private function errorResponse($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ErrorResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Message\ErrorResponse($json)));
     }
 
     /**
@@ -35,7 +36,7 @@ trait JsonApiResponseTrait
     private function resourceCreatedResponse($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ResourceCreatedResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\ResourceCreated($json)));
     }
 
     /**
@@ -46,18 +47,22 @@ trait JsonApiResponseTrait
     private function resourceDeletedResponse($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ResourceDeletedResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\ResourceDeleted($json)));
     }
 
     /**
-     * @param string $json
+     * @param string $type
+     * @param string $id
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    private function resourceNotFoundResponse($json)
+    private function resourceNotFoundResponse($type, $id)
     {
+        $error     = new JsonApi\Server\Errors\NotFoundError($type, $id);
+        $error_bag = new JsonApi\Server\Errors\ErrorBag([$error]);
+
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ResourceNotFoundResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\ResourceNotFound($error_bag)));
     }
 
     /**
@@ -68,7 +73,7 @@ trait JsonApiResponseTrait
     private function resourcePatchErrorResponse($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ResourcePatchErrorResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\ResourcePatchError($json)));
     }
 
     /**
@@ -79,7 +84,7 @@ trait JsonApiResponseTrait
     private function resourcePostErrorResponse($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ResourcePostErrorResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\ResourcePostError($json)));
     }
 
     /**
@@ -90,7 +95,7 @@ trait JsonApiResponseTrait
     private function resourceProcessingResponse($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ResourceProcessingResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\ResourceProcessing($json)));
     }
 
     /**
@@ -101,7 +106,7 @@ trait JsonApiResponseTrait
     private function resourceUpdatedResponse($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\ResourceUpdatedResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\ResourceUpdated($json)));
     }
 
     /**
@@ -112,17 +117,20 @@ trait JsonApiResponseTrait
     private function response($json)
     {
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\Response($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\Response($json)));
     }
 
     /**
-     * @param string $json
+     * @param string $type
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    private function unsupportedActionResponse($json)
+    private function unsupportedActionResponse($type)
     {
+        $error     = new JsonApi\Server\Errors\InvalidTypeError($type);
+        $error_bag = new JsonApi\Server\Errors\ErrorBag([$error]);
+
         return (new HttpFoundationFactory())
-            ->createResponse($this->addHeaders(new \NilPortugues\Api\JsonApi\Http\Message\UnsupportedActionResponse($json)));
+            ->createResponse($this->addHeaders(new JsonApi\Http\Response\UnsupportedAction($error_bag)));
     }
 }


### PR DESCRIPTION
Bones @nilportugues! Estem mirant d'utilitzar el Bundle en un projecte amb l'Albert Lombarte (crec que ja t'ha comentat alguna cosa, pel repo d'exemple que he vist por ahí :D), però ens trobem que el JsonApiResponseTrait crida a alguns namespaces que semblen no existir ja a la llibreria "json-api". 

He mirat de trobar les "correspondències" actualitzades, i en algun cas simplement ha estat corregir una part del namespace, d'altres he vist que canviava la manera de construïr els errors (fes-hi una ullada a veure si tenen sentit els canvis que apunto més avall), però em queden 3 casos sense resoldre. Si em pots orientar una mica amb el tema puc mirar de fer les modificacions necessàries.

Gràcies per l'ajuda i per la feina feta amb aquestes llibreries. ;-)