### PR TITLE
Avoid "Uncaught Warning: Invalid argument supplied for foreach()" warning

### DIFF
--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -59,6 +59,9 @@ class JsonApiSerializer extends \NilPortugues\Api\JsonApi\JsonApiSerializer
             $mappingProperty = $mappingClass->getProperty('otherUrls');
             $mappingProperty->setAccessible(true);
             $otherUrls = $mappingProperty->getValue($mapping);
+            if (empty($otherUrls)) {
+              $otherUrls = [];
+            }
             foreach ($otherUrls as &$url) {
                 $url = $this->getUrlPattern($router, $url, $baseUrl);
             }
@@ -67,6 +70,9 @@ class JsonApiSerializer extends \NilPortugues\Api\JsonApi\JsonApiSerializer
             $mappingProperty = $mappingClass->getProperty('relationshipSelfUrl');
             $mappingProperty->setAccessible(true);
             $relationshipSelfUrl = $mappingProperty->getValue($mapping);
+            if (empty($relationshipSelfUrl) {
+              $relationshipSelfUrl = [];
+            }
             foreach ($relationshipSelfUrl as &$urlMember) {
                 foreach ($urlMember as &$url) {
                     $url = $this->getUrlPattern($router, $url, $baseUrl);

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -60,7 +60,7 @@ class JsonApiSerializer extends \NilPortugues\Api\JsonApi\JsonApiSerializer
             $mappingProperty->setAccessible(true);
             $otherUrls = $mappingProperty->getValue($mapping);
             if (empty($otherUrls)) {
-              $otherUrls = [];
+                $otherUrls = [];
             }
             foreach ($otherUrls as &$url) {
                 $url = $this->getUrlPattern($router, $url, $baseUrl);
@@ -71,7 +71,7 @@ class JsonApiSerializer extends \NilPortugues\Api\JsonApi\JsonApiSerializer
             $mappingProperty->setAccessible(true);
             $relationshipSelfUrl = $mappingProperty->getValue($mapping);
             if (empty($relationshipSelfUrl) {
-              $relationshipSelfUrl = [];
+                $relationshipSelfUrl = [];
             }
             foreach ($relationshipSelfUrl as &$urlMember) {
                 foreach ($urlMember as &$url) {

--- a/src/Serializer/JsonApiSerializer.php
+++ b/src/Serializer/JsonApiSerializer.php
@@ -70,7 +70,7 @@ class JsonApiSerializer extends \NilPortugues\Api\JsonApi\JsonApiSerializer
             $mappingProperty = $mappingClass->getProperty('relationshipSelfUrl');
             $mappingProperty->setAccessible(true);
             $relationshipSelfUrl = $mappingProperty->getValue($mapping);
-            if (empty($relationshipSelfUrl) {
+            if (empty($relationshipSelfUrl)) {
                 $relationshipSelfUrl = [];
             }
             foreach ($relationshipSelfUrl as &$urlMember) {


### PR DESCRIPTION
I'm using php7.1 and catching it...